### PR TITLE
Fix invite link redirection issue

### DIFF
--- a/bot.php
+++ b/bot.php
@@ -642,7 +642,7 @@ if($data=="inviteFriends"){
         
         $link = "t.me/$botId?start=" . $from_id;
         if($inviteText['type'] == "text"){
-            $txt = str_replace('LINK',"<code>$link</code>",$inviteText['text']);
+            $txt = str_replace('LINK',$link,$inviteText['text']);
             $res = sendMessage($txt,null,"HTML");
         } 
         else{


### PR DESCRIPTION
Resolved a bug where the invite link did not redirect users directly to the bot. Instead, it was only copying the link. Now, clicking on the invite link will properly redirect users to the bot